### PR TITLE
Fix set_message_id() in expat parser

### DIFF
--- a/pynzb/expat_nzb.py
+++ b/pynzb/expat_nzb.py
@@ -22,7 +22,7 @@ class ExpatNZBParser(BaseNZBParser):
         elif name == 'group':
             self.current_file.add_group(self.current_data)
         elif name == 'segment':
-            self.current_segment.message_id(self.current_data)
+            self.current_segment.set_message_id(self.current_data)
             self.current_file.add_segment(self.current_segment)
     
     def char_data(self, data):


### PR DESCRIPTION
The `message_id` is an undefined attribute at the point it it called here and so this code currently doesn't run. This replaces it with the intended setter method `set_message_id()`.