### PR TITLE
Enable 2to3 to get most of the way to Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,4 +158,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=['setuptools'],
+    use_2to3=True,
 )


### PR DESCRIPTION
This change enables 2to3 in `setup.py`. It gets us compatible with Python 3 except for the LXML parser which needs a further change due to the string/bytes concept in Python 3.