### PR TITLE
Add Python 3 support to LXML parser

### DIFF
--- a/pynzb/lxml_nzb.py
+++ b/pynzb/lxml_nzb.py
@@ -6,11 +6,17 @@ except ImportError:
     raise ImportError("You must have lxml installed before you can use the " +
         "lxml NZB parser.")
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
+import sys
+if sys.version_info.major < 3:
+    try:
+        from cStringIO import StringIO
+    except ImportError:
+        from StringIO import StringIO
+    def as_io(xml): return StringIO(xml)
+else:
+    from io import BytesIO
+    def as_io(xml): return BytesIO(bytes(xml, 'utf-8'))
 
 class LXMLNZBParser(BaseETreeNZBParser):
     def get_etree_iter(self, xml, et=etree):
-        return iter(et.iterparse(StringIO(xml), events=("start", "end")))
+        return iter(et.iterparse(as_io(xml), events=("start", "end")))


### PR DESCRIPTION
The lxml etree API changed in Python 3 to take BytesIO instead of StringIO. This patch maintains the original behaviour in Python 2 but switches to BytesIO in Python 3, decoding the XML data as UTF-8.

In combination with #5 this change gives is sufficient to get everything working in Python 3. If there turns out to be some problem with assuming UTF-8 encoding then this could either be elaborated upon or the LXML implementation could just be disabled for Python 3 as an easy way out.